### PR TITLE
Allow matrix reordering with Ginkgo direct solver.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ if(SCHWARZ_BUILD_METIS)
   if(NOT DEFINED ENV{METIS_DIR})
     message(FATAL_ERROR "Please specify where METIS has been installed.")
   endif()
+  find_package(METIS REQUIRED)
   set(METIS_INCLUDE_DIR $ENV{METIS_DIR}/include)
   set(METIS_LIBRARY_DIR $ENV{METIS_DIR}/lib)
   find_package(METIS REQUIRED)
@@ -101,6 +102,7 @@ TARGET_SOURCES(${TARGET} PRIVATE
   source/exception.cpp
   )
 
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/config.hpp.in
     ${CMAKE_CURRENT_BINARY_DIR}/include/schwarz/config.hpp @ONLY)
 
@@ -165,7 +167,7 @@ endif()
 
 if(SCHWARZ_BUILD_CUDA)
   TARGET_INCLUDE_DIRECTORIES(${TARGET}
-    SYSTEM PRIVATE ${CUDA_INCLUDE_DIRS})
+    SYSTEM PUBLIC ${CUDA_INCLUDE_DIRS})
   TARGET_LINK_LIBRARIES(${TARGET} ${CUDA_RUNTIME_LIBS} ${CUBLAS} ${CUSPARSE})
 endif()
 

--- a/benchmarking/CMakeLists.txt
+++ b/benchmarking/CMakeLists.txt
@@ -7,8 +7,7 @@ include_directories(
 
 add_executable(${BENCH_TARGET} bench_ras.cpp)
 
-target_link_libraries(${BENCH_TARGET} schwarz)
-
+target_link_libraries(${BENCH_TARGET} PUBLIC schwarz)
 if(SCHWARZ_BUILD_DEALII)
   DEAL_II_SETUP_TARGET(${BENCH_TARGET})
 endif()

--- a/benchmarking/bench_ras.cpp
+++ b/benchmarking/bench_ras.cpp
@@ -96,6 +96,8 @@ DEFINE_string(timings_file, "null", "The filename for the timings");
 DEFINE_bool(write_comm_data, false,
             "Write the number of elements sent and received by each subdomain "
             "to a file.");
+DEFINE_bool(write_perm_data, false,
+            "Write the permutation from CHOLMOD to a file");
 DEFINE_bool(print_config, true, "Print the configuration of the run ");
 DEFINE_string(
     partition, "regular",
@@ -295,6 +297,7 @@ void BenchRas<ValueType, IndexType>::solve(MPI_Comm mpi_communicator)
 
     // Generic settings
     settings.write_debug_out = FLAGS_enable_debug_write;
+    settings.write_perm_data = FLAGS_write_perm_data;
     settings.shifted_iter = FLAGS_shifted_iter;
 
     // Set solver settings from command line args.

--- a/include/initialization.hpp
+++ b/include/initialization.hpp
@@ -160,7 +160,9 @@ public:
         std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>> &local_matrix,
         std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>>
             &interface_matrix,
-        std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_perm) = 0;
+        std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_perm,
+        std::shared_ptr<gko::matrix::Permutation<IndexType>>
+            &local_inv_perm) = 0;
 
 private:
     Settings &settings;

--- a/include/partition_tools.hpp
+++ b/include/partition_tools.hpp
@@ -183,15 +183,17 @@ void PartitionMetis(
     if (nparts <= 8) {
         SCHWARZ_ASSERT_NO_METIS_ERRORS(METIS_PartGraphRecursive(
             &n, &ncon, int_rowstart.data(), int_colnums.data(),
-            p_int_cell_weights, nullptr, nullptr, &nparts, nullptr, nullptr,
-            options, &dummy, int_partition_indices.data()));
+            // p_int_cell_weights, nullptr, nullptr, &nparts, nullptr, nullptr,
+            nullptr, nullptr, nullptr, &nparts, nullptr, nullptr, options,
+            &dummy, int_partition_indices.data()));
     }
     // Otherwise use kway
     else {
         SCHWARZ_ASSERT_NO_METIS_ERRORS(METIS_PartGraphKway(
             &n, &ncon, int_rowstart.data(), int_colnums.data(),
-            p_int_cell_weights, nullptr, nullptr, &nparts, nullptr, nullptr,
-            options, &dummy, int_partition_indices.data()));
+            // p_int_cell_weights, nullptr, nullptr, &nparts, nullptr, nullptr,
+            nullptr, nullptr, nullptr, &nparts, nullptr, nullptr, options,
+            &dummy, int_partition_indices.data()));
     }
 
     // now copy back generated indices into the output array

--- a/include/schwarz_solver.hpp
+++ b/include/schwarz_solver.hpp
@@ -133,9 +133,14 @@ public:
     std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>> local_matrix;
 
     /**
-     * The local subdomain rcm permutation matrix.
+     * The local subdomain permutation matrix/array.
      */
     std::shared_ptr<gko::matrix::Permutation<IndexType>> local_perm;
+
+    /**
+     * The local subdomain inverse permutation matrix/array.
+     */
+    std::shared_ptr<gko::matrix::Permutation<IndexType>> local_inv_perm;
 
     /**
      * The local triangular factor used for the triangular solves.
@@ -226,7 +231,8 @@ public:
         std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>> &local_matrix,
         std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>>
             &interface_matrix,
-        std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_perm)
+        std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_perm,
+        std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_inv_perm)
         override;
 
     void setup_comm_buffers() override;

--- a/include/settings.hpp
+++ b/include/settings.hpp
@@ -162,6 +162,11 @@ struct Settings {
     bool write_debug_out = false;
 
     /**
+     * Enable the local permutations from CHOLMOD to a file.
+     */
+    bool write_perm_data = false;
+
+    /**
      * Iteration shift for node local communication.
      */
     int shifted_iter = 1;

--- a/include/solve.hpp
+++ b/include/solve.hpp
@@ -109,6 +109,8 @@ protected:
             &local_matrix,
         std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>>
             &triangular_factor,
+        std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_perm,
+        std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_inv_perm,
         std::shared_ptr<gko::matrix::Dense<ValueType>> &local_rhs);
 
     /**
@@ -125,6 +127,8 @@ protected:
         const Metadata<ValueType, IndexType> &metadata,
         const std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>>
             &triangular_factor,
+        std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_perm,
+        std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_inv_perm,
         std::shared_ptr<gko::matrix::Dense<ValueType>> &init_guess,
         std::shared_ptr<gko::matrix::Dense<ValueType>> &local_solution);
 

--- a/include/solver_tools.hpp
+++ b/include/solver_tools.hpp
@@ -51,7 +51,7 @@ void solve_direct_ginkgo(
         &L_solver,
     const std::shared_ptr<gko::solver::UpperTrs<ValueType, IndexType>>
         &U_solver,
-    std::shared_ptr<gko::matrix::Dense<ValueType>> &local_solution)
+    gko::matrix::Dense<ValueType> *local_solution)
 {
     using vec = gko::matrix::Dense<ValueType>;
     auto temp_rhs = vec::create(settings.executor, local_solution->get_size());

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -67,6 +67,12 @@ struct Utils {
 
     static void print_vector(const gko::matrix::Dense<ValueType> *vector,
                              int rank, std::string name);
+
+    static int find_duplicates(IndexType val, std::size_t index,
+                               const IndexType *data, std::size_t length);
+
+    static bool assert_correct_permutation(
+        const gko::matrix::Permutation<IndexType> *input_perm);
 };
 
 

--- a/matlab_tests/reorder_test.m
+++ b/matlab_tests/reorder_test.m
@@ -1,0 +1,32 @@
+clear all
+
+A = delsq(numgrid('S',20));
+N = length(A);
+
+r = symamd(A);
+for i=1:length(r)
+    ir(r(1,i)) = i;
+end
+L1 = chol(A);
+L2 = chol(A(r,r));
+subplot(1,2,1),spy(L1),title('L')
+subplot(1,2,2),spy(L2),title('L(p,p)')
+L1t = transpose(L1);
+L2t = transpose(L2);
+
+b = rand(size(A,1),1);
+br = b(r,1);
+err1 = norm(abs(b-br),2);
+x_it = pcg(A,b,1e-10,1000);
+x_di = (L1\(L1t\b));
+x_di2 = (L2\(L2t\br));
+x_di3 = A(r,r)\br;
+x_di2 = x_di2(ir,1);
+x_di3 = x_di3(ir,1);
+
+err = norm(abs(x_di-x_it),2);
+err2 = norm(abs(x_di2-x_it),2);
+err3 = norm(abs(x_di3-x_it),2);
+
+
+

--- a/source/initialization.cpp
+++ b/source/initialization.cpp
@@ -69,7 +69,8 @@ void Initialize<ValueType, IndexType>::setup_local_matrices(
     std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>> &global_matrix,
     std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>> &local_matrix,
     std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>> &interface_matrix,
-    std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_perm)
+    std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_perm,
+    std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_inv_perm)
     SCHWARZ_NOT_IMPLEMENTED;
 
 

--- a/source/utils.cpp
+++ b/source/utils.cpp
@@ -91,6 +91,49 @@ void Utils<ValueType, IndexType>::print_matrix(
 }
 
 
+template <typename ValueType, typename IndexType>
+int Utils<ValueType, IndexType>::find_duplicates(IndexType val,
+                                                 std::size_t index,
+                                                 const IndexType *data,
+                                                 std::size_t length)
+{
+    auto count = 0;
+    for (auto i = 0; i < length; ++i) {
+        if (i != index && val == data[i]) {
+            count++;
+        }
+    }
+    return count;
+}
+
+
+template <typename ValueType, typename IndexType>
+bool Utils<ValueType, IndexType>::assert_correct_permutation(
+    const gko::matrix::Permutation<IndexType> *input_perm)
+{
+    auto perm_data = input_perm->get_const_permutation();
+    auto perm_size = input_perm->get_permutation_size();
+
+    for (auto i = 0; i < perm_size; ++i) {
+        if (perm_data[i] >= perm_size) {
+            std::cout << "Here " << __LINE__ << ", perm[i] " << perm_data[i]
+                      << " at " << i << std::endl;
+            return false;
+        }
+        if (perm_data[i] < 0) {
+            std::cout << "Here " << __LINE__ << std::endl;
+            return false;
+        }
+        auto duplicates = Utils<ValueType, IndexType>::find_duplicates(
+            perm_data[i], i, perm_data, perm_size);
+        if (duplicates > 0) {
+            std::cout << "Here " << __LINE__ << " " << duplicates << std::endl;
+            return false;
+        }
+    }
+}
+
+
 #define DECLARE_UTILS(ValueType, IndexType) struct Utils<ValueType, IndexType>
 INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(DECLARE_UTILS);
 #undef DECLARE_UTILS


### PR DESCRIPTION
Taking the permutation from CHOLMOD, permute the rhs and solution vectors in the local solve .

+ Currently, the default permutation from CHOLMOD is used, which is either AMD (Approximate minimum degree) or METIS permutations. Check the [CHOLMOD documentation](https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/master/CHOLMOD/Doc/CHOLMOD_UserGuide.pdf) for more details.