### PR TITLE
Improve local iterative solver performance

### DIFF
--- a/benchmarking/bench_ras.cpp
+++ b/benchmarking/bench_ras.cpp
@@ -100,6 +100,8 @@ DEFINE_bool(write_comm_data, false,
             "to a file.");
 DEFINE_bool(write_perm_data, false,
             "Write the permutation from CHOLMOD to a file");
+DEFINE_bool(write_iters_and_residuals, false,
+            "Write the iteration and residual log to a file");
 DEFINE_bool(print_matrices, false,
             "Write the local system matrices for debugging");
 DEFINE_bool(print_config, true, "Print the configuration of the run ");
@@ -120,9 +122,11 @@ DEFINE_uint32(num_threads, 1, "Number of threads to bind to a process");
 DEFINE_bool(factor_ordering_natural, false,
             "If true uses natural ordering instead of the default optimized "
             "ordering. ");
-DEFINE_bool(enable_local_precond, false,
-            "If true uses the Block jacobi preconditioning for the local "
-            "iterative solver. ");
+DEFINE_int32(local_max_iters, -1,
+             "Number of maximum iterations for the local iterative solver");
+DEFINE_string(local_precond, "null",
+              "Choices are ilu, parilu and block-jacobi for the local "
+              "iterative solver. ");
 DEFINE_uint32(precond_max_block_size, 16,
               "Maximum size of the blocks for the block jacobi preconditioner");
 DEFINE_string(metis_objtype, "null",
@@ -303,6 +307,7 @@ void BenchRas<ValueType, IndexType>::solve(MPI_Comm mpi_communicator)
     // Generic settings
     settings.write_debug_out = FLAGS_enable_debug_write;
     settings.write_perm_data = FLAGS_write_perm_data;
+    settings.write_iters_and_residuals = FLAGS_write_iters_and_residuals;
     settings.print_matrices = FLAGS_print_matrices;
     settings.shifted_iter = FLAGS_shifted_iter;
 
@@ -349,8 +354,10 @@ void BenchRas<ValueType, IndexType>::solve(MPI_Comm mpi_communicator)
 
     // General solver settings
     metadata.local_solver_tolerance = FLAGS_local_tol;
-    settings.use_precond = FLAGS_enable_local_precond;
+    metadata.local_precond = FLAGS_local_precond;
+    metadata.local_max_iters = FLAGS_local_max_iters;
     settings.non_symmetric_matrix = FLAGS_non_symmetric_matrix;
+    metadata.precond_max_block_size = FLAGS_precond_max_block_size;
     metadata.precond_max_block_size = FLAGS_precond_max_block_size;
     settings.matrix_filename = FLAGS_matrix_filename;
     settings.explicit_laplacian = FLAGS_explicit_laplacian;

--- a/include/conv_tools.hpp
+++ b/include/conv_tools.hpp
@@ -43,19 +43,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace schwz {
 /**
- * @brief The ConvergenceTools namespace .
+ * @brief The conv_tools namespace .
  * @ref conv_tools
  * @ingroup solve
  */
-namespace ConvergenceTools {
+namespace conv_tools {
 
 
 template <typename ValueType, typename IndexType>
 void put_all_local_residual_norms(
-    const Settings &settings, const Metadata<ValueType, IndexType> &metadata,
+    const Settings &settings, Metadata<ValueType, IndexType> &metadata,
     ValueType &local_resnorm,
     std::shared_ptr<gko::matrix::Dense<ValueType>> &local_residual_vector,
-    std::vector<std::vector<ValueType>> &global_residual_vector_out,
     MPI_Win &window_residual_vector)
 {
     auto num_subdomains = metadata.num_subdomains;
@@ -66,7 +65,8 @@ void put_all_local_residual_norms(
 
     l_res_vec[my_rank] = std::min(l_res_vec[my_rank], local_resnorm);
     for (auto j = 0; j < num_subdomains; j++) {
-        auto gres = global_residual_vector_out[my_rank];
+        auto gres =
+            metadata.post_process_data.global_residual_vector_out[my_rank];
         if (j != my_rank && iter > 0 && l_res_vec[my_rank] != gres[iter - 1]) {
             MPI_Put(&l_res_vec[my_rank], 1, mpi_vtype, j, my_rank, 1, mpi_vtype,
                     window_residual_vector);
@@ -82,11 +82,10 @@ void put_all_local_residual_norms(
 
 template <typename ValueType, typename IndexType>
 void propagate_all_local_residual_norms(
-    const Settings &settings, const Metadata<ValueType, IndexType> &metadata,
+    const Settings &settings, Metadata<ValueType, IndexType> &metadata,
     struct Communicate<ValueType, IndexType>::comm_struct &comm_s,
     ValueType &local_resnorm,
     std::shared_ptr<gko::matrix::Dense<ValueType>> &local_residual_vector,
-    std::vector<std::vector<ValueType>> &global_residual_vector_out,
     MPI_Win &window_residual_vector)
 {
     auto num_subdomains = metadata.num_subdomains;
@@ -99,7 +98,7 @@ void propagate_all_local_residual_norms(
     auto mpi_vtype = boost::mpi::get_mpi_datatype(l_res_vec[my_rank]);
 
     l_res_vec[my_rank] = std::min(l_res_vec[my_rank], local_resnorm);
-    auto gres = global_residual_vector_out[my_rank];
+    auto gres = metadata.post_process_data.global_residual_vector_out[my_rank];
     for (auto i = 0; i < comm_s.num_neighbors_out; i++) {
         if ((global_put[i])[0] > 0) {
             auto p = neighbors_out[i];
@@ -109,7 +108,8 @@ void propagate_all_local_residual_norms(
                 for (auto j = 0; j < num_subdomains; j++) {
                     if (j != p && iter > 0 && l_res_vec[j] != max_valtype &&
                         l_res_vec[j] !=
-                            (global_residual_vector_out[j])[iter - 1]) {
+                            (metadata.post_process_data
+                                 .global_residual_vector_out[j])[iter - 1]) {
                         flag++;
                     }
                 }
@@ -120,7 +120,8 @@ void propagate_all_local_residual_norms(
                          (iter == 0 || l_res_vec[my_rank] != gres[iter - 1])) ||
                         (j != p && iter > 0 && l_res_vec[j] != max_valtype &&
                          l_res_vec[j] !=
-                             (global_residual_vector_out[j])[iter - 1])) {
+                             (metadata.post_process_data
+                                  .global_residual_vector_out[j])[iter - 1])) {
                         // double result;
                         MPI_Accumulate(&l_res_vec[j], 1, mpi_vtype, p, j, 1,
                                        mpi_vtype, MPI_MIN,
@@ -284,44 +285,7 @@ void global_convergence_decentralized(
 }
 
 
-}  // namespace ConvergenceTools
-
-// Explicit Instantiations
-#define DECLARE_FUNCTION(ValueType, IndexType)                                 \
-    void ConvergenceTools::put_all_local_residual_norms(                       \
-        const Settings &, const Metadata<ValueType, IndexType> &, ValueType &, \
-        std::shared_ptr<gko::matrix::Dense<ValueType>> &,                      \
-        std::vector<std::vector<ValueType>> &, MPI_Win &);
-INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(DECLARE_FUNCTION);
-#undef DECLARE_FUNCTION
-
-#define DECLARE_FUNCTION2(ValueType, IndexType)                               \
-    void ConvergenceTools::propagate_all_local_residual_norms(                \
-        const Settings &, const Metadata<ValueType, IndexType> &,             \
-        struct Communicate<ValueType, IndexType>::comm_struct &, ValueType &, \
-        std::shared_ptr<gko::matrix::Dense<ValueType>> &,                     \
-        std::vector<std::vector<ValueType>> &, MPI_Win &);
-INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(DECLARE_FUNCTION2);
-#undef DECLARE_FUNCTION2
-
-#define DECLARE_FUNCTION3(ValueType, IndexType)                    \
-    void ConvergenceTools::global_convergence_check_onesided_tree( \
-        const Settings &, const Metadata<ValueType, IndexType> &,  \
-        std::shared_ptr<gko::Array<IndexType>> &, int &, int &, MPI_Win &);
-INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(DECLARE_FUNCTION3);
-#undef DECLARE_FUNCTION3
-
-#define DECLARE_FUNCTION4(ValueType, IndexType)                   \
-    void ConvergenceTools::global_convergence_decentralized(      \
-        const Settings &, const Metadata<ValueType, IndexType> &, \
-        struct Communicate<ValueType, IndexType>::comm_struct &,  \
-        std::shared_ptr<gko::Array<IndexType>> &,                 \
-        std::shared_ptr<gko::Array<IndexType>> &,                 \
-        std::shared_ptr<gko::Array<IndexType>> &, int &, int &, MPI_Win &);
-INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(DECLARE_FUNCTION4);
-#undef DECLARE_FUNCTION4
-
-
+}  // namespace conv_tools
 }  // namespace schwz
 
 

--- a/include/schwarz_base.hpp
+++ b/include/schwarz_base.hpp
@@ -185,6 +185,16 @@ public:
      */
     std::shared_ptr<gko::matrix::Dense<ValueType>> global_solution;
 
+    /**
+     * The global residual vector.
+     */
+    std::vector<ValueType> local_residual_vector_out;
+
+    /**
+     * The local residual vector.
+     */
+    std::vector<std::vector<ValueType>> global_residual_vector_out;
+
 protected:
     /**
      * The settings struct used to store the solver and other auxiliary

--- a/include/settings.hpp
+++ b/include/settings.hpp
@@ -173,6 +173,11 @@ struct Settings {
     bool write_debug_out = false;
 
     /**
+     * Enable writing the iters and residuals to a file.
+     */
+    bool write_iters_and_residuals = false;
+
+    /**
      * Enable the local permutations from CHOLMOD to a file.
      */
     bool write_perm_data = false;
@@ -367,9 +372,19 @@ struct Metadata {
     ValueType local_solver_tolerance;
 
     /**
-     * The maximum iteration count of the solver.
+     * The maximum iteration count of the Schwarz solver.
      */
     IndexType max_iters;
+
+    /**
+     * The maximum iteration count of the local iterative solver.
+     */
+    IndexType local_max_iters;
+
+    /**
+     * Local preconditioner.
+     */
+    std::string local_precond;
 
     /**
      * The maximum block size for the preconditioner.

--- a/include/settings.hpp
+++ b/include/settings.hpp
@@ -417,6 +417,18 @@ struct Metadata {
         comm_data_struct;
 
     /**
+     * The struct used for storing data for post-processing.
+     *
+     */
+    struct post_process_data {
+        std::vector<std::vector<ValueType>> global_residual_vector_out;
+        std::vector<ValueType> local_residual_vector_out;
+        std::vector<ValueType> local_converged_iter_count;
+        std::vector<ValueType> local_converged_resnorm;
+    };
+    post_process_data post_process_data;
+
+    /**
      * The mapping containing the global to local indices.
      */
     std::shared_ptr<gko::Array<IndexType>> global_to_local;

--- a/include/solve.hpp
+++ b/include/solve.hpp
@@ -61,6 +61,10 @@ template <typename ValueType = gko::default_precision,
           typename IndexType = gko::int32>
 class Solve : public Settings {
 public:
+    using ResidualCriterionFactory =
+        typename gko::stop::ResidualNormReduction<ValueType>::Factory;
+    using IterationCriterionFactory = typename gko::stop::Iteration::Factory;
+
     Solve() = default;
 
     Solve(const Settings &settings);
@@ -70,9 +74,9 @@ public:
 protected:
     std::shared_ptr<gko::matrix::Dense<ValueType>> local_residual_vector;
 
-    std::shared_ptr<gko::matrix::Dense<ValueType>> local_residual_vector_out;
+    std::vector<ValueType> local_residual_vector_out;
 
-    std::shared_ptr<gko::matrix::Dense<ValueType>> global_residual_vector_out;
+    std::vector<std::vector<ValueType>> global_residual_vector_out;
 
     std::shared_ptr<gko::matrix::Dense<ValueType>> residual_vector;
 
@@ -157,6 +161,7 @@ protected:
             &triangular_factor_u,
         std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_perm,
         std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_inv_perm,
+        std::shared_ptr<gko::matrix::Dense<ValueType>> &work_vector,
         std::shared_ptr<gko::matrix::Dense<ValueType>> &init_guess,
         std::shared_ptr<gko::matrix::Dense<ValueType>> &local_solution);
 
@@ -290,6 +295,21 @@ private:
      * The local iterative solver from Ginkgo.
      */
     std::shared_ptr<gko::LinOp> solver;
+
+    /**
+     * The local iterative solver residual criterion.
+     */
+    std::shared_ptr<ResidualCriterionFactory> residual_criterion;
+
+    /**
+     * The local iterative solver iteration criterion.
+     */
+    std::shared_ptr<IterationCriterionFactory> iteration_criterion;
+
+    /**
+     * The local iterative solver iteration criterion.
+     */
+    std::shared_ptr<gko::log::Record> record_logger;
 
     /**
      * The local lower triangular solver from Ginkgo.

--- a/include/solve.hpp
+++ b/include/solve.hpp
@@ -74,10 +74,6 @@ public:
 protected:
     std::shared_ptr<gko::matrix::Dense<ValueType>> local_residual_vector;
 
-    std::vector<ValueType> local_residual_vector_out;
-
-    std::vector<std::vector<ValueType>> global_residual_vector_out;
-
     std::shared_ptr<gko::matrix::Dense<ValueType>> residual_vector;
 
     std::shared_ptr<gko::Array<IndexType>> convergence_vector;
@@ -118,6 +114,7 @@ protected:
             &triangular_factor_l,
         std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>>
             &triangular_factor_u,
+        std::vector<std::vector<ValueType>> &global_residual_vector_out,
         std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_perm,
         std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_inv_perm,
         std::shared_ptr<gko::matrix::Dense<ValueType>> &local_rhs);
@@ -192,6 +189,8 @@ protected:
         const std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>>
             &local_matrix,
         std::shared_ptr<gko::matrix::Dense<ValueType>> &work_vector,
+        std::vector<ValueType> &local_residual_vector_out,
+        std::vector<std::vector<ValueType>> &global_residual_vector_out,
         ValueType &local_residual_norm, ValueType &local_residual_norm0,
         ValueType &global_residual_norm, ValueType &global_residual_norm0,
         int &num_converged_procs);
@@ -216,6 +215,7 @@ protected:
         const Metadata<ValueType, IndexType> &metadata,
         struct Communicate<ValueType, IndexType>::comm_struct &comm_struct,
         std::shared_ptr<gko::Array<IndexType>> &convergence_vector,
+        std::vector<std::vector<ValueType>> &global_residual_vector_out,
         ValueType &local_resnorm, ValueType &local_resnorm0,
         ValueType &global_resnorm, ValueType &global_resnorm0,
         int &converged_all_local, int &num_converged_procs);

--- a/include/solve.hpp
+++ b/include/solve.hpp
@@ -106,15 +106,13 @@ protected:
      * @param local_rhs  The local right hand side vector in the subdomain.
      */
     void setup_local_solver(
-        const Settings &settings,
-        const Metadata<ValueType, IndexType> &metadata,
+        const Settings &settings, Metadata<ValueType, IndexType> &metadata,
         const std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>>
             &local_matrix,
         std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>>
             &triangular_factor_l,
         std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>>
             &triangular_factor_u,
-        std::vector<std::vector<ValueType>> &global_residual_vector_out,
         std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_perm,
         std::shared_ptr<gko::matrix::Permutation<IndexType>> &local_inv_perm,
         std::shared_ptr<gko::matrix::Dense<ValueType>> &local_rhs);
@@ -148,8 +146,7 @@ protected:
      * @param local_solution The local solution vector in the subdomain.
      */
     void local_solve(
-        const Settings &settings,
-        const Metadata<ValueType, IndexType> &metadata,
+        const Settings &settings, Metadata<ValueType, IndexType> &metadata,
         const std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>>
             &local_matrix,
         const std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>>
@@ -189,8 +186,6 @@ protected:
         const std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>>
             &local_matrix,
         std::shared_ptr<gko::matrix::Dense<ValueType>> &work_vector,
-        std::vector<ValueType> &local_residual_vector_out,
-        std::vector<std::vector<ValueType>> &global_residual_vector_out,
         ValueType &local_residual_norm, ValueType &local_residual_norm0,
         ValueType &global_residual_norm, ValueType &global_residual_norm0,
         int &num_converged_procs);
@@ -211,11 +206,9 @@ protected:
      * @param num_converged_procs  The number of subdomains that have converged.
      */
     void check_global_convergence(
-        const Settings &settings,
-        const Metadata<ValueType, IndexType> &metadata,
+        const Settings &settings, Metadata<ValueType, IndexType> &metadata,
         struct Communicate<ValueType, IndexType>::comm_struct &comm_struct,
         std::shared_ptr<gko::Array<IndexType>> &convergence_vector,
-        std::vector<std::vector<ValueType>> &global_residual_vector_out,
         ValueType &local_resnorm, ValueType &local_resnorm0,
         ValueType &global_resnorm, ValueType &global_resnorm0,
         int &converged_all_local, int &num_converged_procs);

--- a/source/schwarz_base.cpp
+++ b/source/schwarz_base.cpp
@@ -43,6 +43,37 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace schwz {
 
+template <typename ValueType>
+void write_iters_and_residuals(int num_subd, int my_rank, int iter_count,
+                               std::vector<ValueType> &local_res_vec_out,
+                               std::string filename)
+{
+    {
+        std::ofstream file;
+        file.open(filename);
+        file << "iter,resnorm\n";
+        for (auto i = 0; i < iter_count; ++i) {
+            file << i << "," << local_res_vec_out[i] << "\n";
+        }
+        file.close();
+    }
+    // {
+    //     std::ofstream file;
+    //     file.open(filename_recv);
+    //     file << "subdomain " << my_rank << " has "
+    //          << std::get<3>(comm_data_struct[my_rank]) << " neighbors\n";
+    //     file << "my_id,from_id,num_recv\n";
+    //     for (auto i = 0; i < num_subd; ++i) {
+    //         file << my_rank << ","
+    //              << std::get<0>(std::get<1>(comm_data_struct[my_rank])[i])
+    //              << ","
+    //              << std::get<1>(std::get<1>(comm_data_struct[my_rank])[i])
+    //              << "\n";
+    //     }
+    //     file.close();
+    // }
+}
+
 
 template <typename ValueType, typename IndexType>
 SchwarzBase<ValueType, IndexType>::SchwarzBase(
@@ -294,6 +325,10 @@ void SchwarzBase<ValueType, IndexType>::run(
     // A work vector.
     std::shared_ptr<vec_vtype> work_vector = vec_vtype::create(
         settings.executor, gko::dim<2>(2 * this->metadata.local_size_x, 1));
+    // An initial guess.
+    std::shared_ptr<vec_vtype> init_guess = vec_vtype::create(
+        settings.executor, gko::dim<2>(this->metadata.local_size_x, 1));
+    init_guess->copy_from(local_rhs.get());
     // Setup the windows for the onesided communication.
     this->setup_windows(this->settings, this->metadata, global_solution);
 
@@ -353,9 +388,8 @@ void SchwarzBase<ValueType, IndexType>::run(
                     settings, metadata, this->local_matrix,
                     this->triangular_factor_l, this->triangular_factor_u,
                     this->local_perm, this->local_inv_perm, work_vector,
-                    this->local_solution)),
+                    init_guess, this->local_solution)),
                 3, metadata.my_rank, local_solve, metadata.iter_count);
-            // init_guess->copy_from(this->local_solution.get());
             // Gather the local vector into the locally global vector for
             // communication.
             MEASURE_ELAPSED_FUNC_TIME(
@@ -371,6 +405,18 @@ void SchwarzBase<ValueType, IndexType>::run(
               << metadata.iter_count << " iters " << std::endl;
     ValueType mat_norm = -1.0, rhs_norm = -1.0, sol_norm = -1.0,
               residual_norm = -1.0;
+    // Write the residuals and iterations to files
+    if (settings.write_iters_and_residuals) {
+        std::string rank_string = std::to_string(metadata.my_rank);
+        if (metadata.my_rank < 10) {
+            rank_string = "0" + std::to_string(metadata.my_rank);
+        }
+        std::string filename = "iter_res_" + rank_string + ".csv";
+        write_iters_and_residuals(metadata.num_subdomains, metadata.my_rank,
+                                  local_res_vec.size(), local_res_vec,
+                                  filename);
+    }
+
     // Compute the final residual norm. Also gathers the solution from all
     // subdomains.
     Solve<ValueType, IndexType>::compute_residual_norm(

--- a/source/schwarz_base.cpp
+++ b/source/schwarz_base.cpp
@@ -257,8 +257,8 @@ void SchwarzBase<ValueType, IndexType>::initialize(
     // Setup the local solver on each of the subddomains.
     Solve<ValueType, IndexType>::setup_local_solver(
         this->settings, metadata, this->local_matrix, this->triangular_factor_l,
-        this->triangular_factor_u, this->local_perm, this->local_inv_perm,
-        this->local_rhs);
+        this->triangular_factor_u, this->global_residual_vector_out,
+        this->local_perm, this->local_inv_perm, this->local_rhs);
     // Setup the communication buffers on each of the subddomains.
     this->setup_comm_buffers();
 }
@@ -366,9 +366,10 @@ void SchwarzBase<ValueType, IndexType>::run(
             (Solve<ValueType, IndexType>::check_convergence(
                 settings, metadata, this->comm_struct, this->convergence_vector,
                 global_solution, this->local_solution, this->local_matrix,
-                work_vector, local_residual_norm, local_residual_norm0,
-                global_residual_norm, global_residual_norm0,
-                num_converged_procs)),
+                work_vector, this->local_residual_vector_out,
+                this->global_residual_vector_out, local_residual_norm,
+                local_residual_norm0, global_residual_norm,
+                global_residual_norm0, num_converged_procs)),
             2, metadata.my_rank, convergence_check, metadata.iter_count);
 
         // break if the solution diverges.
@@ -413,8 +414,8 @@ void SchwarzBase<ValueType, IndexType>::run(
         }
         std::string filename = "iter_res_" + rank_string + ".csv";
         write_iters_and_residuals(metadata.num_subdomains, metadata.my_rank,
-                                  local_res_vec.size(), local_res_vec,
-                                  filename);
+                                  this->local_residual_vector_out.size(),
+                                  this->local_residual_vector_out, filename);
     }
 
     // Compute the final residual norm. Also gathers the solution from all


### PR DESCRIPTION
This PR improves the local iterative solver performance by choosing a proper initial guess, and allowing for setting preconditioners and factory parameters for the local solver.

+ Also adds some logging functionality from Ginkgo (res, num_iters) and prints to a file.