### PR TITLE
Allow criterion reset between local solves.

### DIFF
--- a/benchmarking/bench_base.hpp
+++ b/benchmarking/bench_base.hpp
@@ -109,6 +109,8 @@ DEFINE_bool(print_config, true, "Print the configuration of the run ");
 DEFINE_string(
     partition, "regular",
     "The partitioner used. The choices are metis, regular, regular2d");
+DEFINE_bool(enable_logging, false,
+            "Enable some logs for the local iterative solver. ");
 DEFINE_string(local_solver, "iterative-ginkgo",
               "The local solver used in the local domains. The current choices "
               "include direct-cholmod , direct-ginkgo or iterative-ginkgo");
@@ -125,6 +127,9 @@ DEFINE_bool(factor_ordering_natural, false,
             "ordering. ");
 DEFINE_int32(local_max_iters, -1,
              "Number of maximum iterations for the local iterative solver");
+DEFINE_int32(
+    updated_max_iters, -1,
+    "Number of updated maximum iterations for the local iterative solver");
 DEFINE_string(local_precond, "null",
               "Choices are ilu, isai and block-jacobi for the local "
               "iterative solver. ");

--- a/benchmarking/bench_base.hpp
+++ b/benchmarking/bench_base.hpp
@@ -130,6 +130,8 @@ DEFINE_int32(local_max_iters, -1,
 DEFINE_int32(
     updated_max_iters, -1,
     "Number of updated maximum iterations for the local iterative solver");
+DEFINE_int32(reset_local_crit_iter, -1,
+             "The RAS iter count at which to reset the local iteration.");
 DEFINE_string(local_precond, "null",
               "Choices are ilu, isai and block-jacobi for the local "
               "iterative solver. ");

--- a/benchmarking/dealii_ex_6.cpp
+++ b/benchmarking/dealii_ex_6.cpp
@@ -239,9 +239,10 @@ void BenchDealiiLaplace<dim, ValueType, IndexType>::solve(
     metadata.local_solver_tolerance = FLAGS_local_tol;
     metadata.local_precond = FLAGS_local_precond;
     metadata.local_max_iters = FLAGS_local_max_iters;
+    metadata.updated_max_iters = FLAGS_updated_max_iters;
     settings.non_symmetric_matrix = FLAGS_non_symmetric_matrix;
     settings.restart_iter = FLAGS_restart_iter;
-    metadata.precond_max_block_size = FLAGS_precond_max_block_size;
+    settings.enable_logging = FLAGS_enable_logging;
     metadata.precond_max_block_size = FLAGS_precond_max_block_size;
     settings.matrix_filename = FLAGS_matrix_filename;
     settings.explicit_laplacian = FLAGS_explicit_laplacian;

--- a/benchmarking/dealii_ex_9.cpp
+++ b/benchmarking/dealii_ex_9.cpp
@@ -445,9 +445,10 @@ void AdvectionProblem<dim>::solve(MPI_Comm mpi_communicator)
     metadata.local_solver_tolerance = FLAGS_local_tol;
     metadata.local_precond = FLAGS_local_precond;
     metadata.local_max_iters = FLAGS_local_max_iters;
+    metadata.updated_max_iters = FLAGS_updated_max_iters;
     settings.non_symmetric_matrix = FLAGS_non_symmetric_matrix;
     settings.restart_iter = FLAGS_restart_iter;
-    metadata.precond_max_block_size = FLAGS_precond_max_block_size;
+    settings.enable_logging = FLAGS_enable_logging;
     metadata.precond_max_block_size = FLAGS_precond_max_block_size;
     settings.matrix_filename = FLAGS_matrix_filename;
     settings.explicit_laplacian = FLAGS_explicit_laplacian;

--- a/benchmarking/dealii_ex_9.cpp
+++ b/benchmarking/dealii_ex_9.cpp
@@ -448,6 +448,7 @@ void AdvectionProblem<dim>::solve(MPI_Comm mpi_communicator)
     metadata.updated_max_iters = FLAGS_updated_max_iters;
     settings.non_symmetric_matrix = FLAGS_non_symmetric_matrix;
     settings.restart_iter = FLAGS_restart_iter;
+    settings.reset_local_crit_iter = FLAGS_reset_local_crit_iter;
     settings.enable_logging = FLAGS_enable_logging;
     metadata.precond_max_block_size = FLAGS_precond_max_block_size;
     settings.matrix_filename = FLAGS_matrix_filename;

--- a/include/settings.hpp
+++ b/include/settings.hpp
@@ -158,6 +158,11 @@ struct Settings {
     unsigned int restart_iter = 1u;
 
     /**
+     * The global iter at which to reset the local solver criterion.
+     */
+    int reset_local_crit_iter = -1;
+
+    /**
      * Disables the re-ordering of the matrix before computing the triangular
      * factors during the CHOLMOD factorization
      *

--- a/include/settings.hpp
+++ b/include/settings.hpp
@@ -186,6 +186,12 @@ struct Settings {
     bool write_iters_and_residuals = false;
 
     /**
+     * Flag to enable logging for local iterative solvers.
+     * Note: Probably will have a significant performance hit.
+     */
+    bool enable_logging = false;
+
+    /**
      * Enable the local permutations from CHOLMOD to a file.
      */
     bool write_perm_data = false;
@@ -388,6 +394,11 @@ struct Metadata {
      * The maximum iteration count of the local iterative solver.
      */
     IndexType local_max_iters;
+
+    /**
+     * The updated maximum iteration count of the local iterative solver.
+     */
+    IndexType updated_max_iters;
 
     /**
      * Local preconditioner.

--- a/include/solve.hpp
+++ b/include/solve.hpp
@@ -292,12 +292,12 @@ private:
     /**
      * The local iterative solver residual criterion.
      */
-    std::shared_ptr<ResidualCriterionFactory> residual_criterion;
+    std::shared_ptr<gko::stop::Combined::Factory> combined_criterion;
 
-    /**
-     * The local iterative solver iteration criterion.
-     */
-    std::shared_ptr<IterationCriterionFactory> iteration_criterion;
+    // /**
+    //  * The local iterative solver iteration criterion.
+    //  */
+    // std::shared_ptr<IterationCriterionFactory> iteration_criterion;
 
     /**
      * The local iterative solver iteration criterion.

--- a/source/solve.cpp
+++ b/source/solve.cpp
@@ -726,16 +726,20 @@ void Solve<ValueType, IndexType>::local_solve(
         } else {
             new_max_iters = metadata.updated_max_iters;
         }
-        this->combined_criterion =
-            gko::stop::Combined::build()
-                .with_criteria(
-                    gko::stop::Iteration::build()
-                        .with_max_iters(new_max_iters)
-                        .on(settings.executor),
-                    gko::stop::ResidualNormReduction<ValueType>::build()
-                        .with_reduction_factor(metadata.local_solver_tolerance)
-                        .on(settings.executor))
-                .on(settings.executor);
+        if (settings.reset_local_crit_iter != -1 &&
+            metadata.iter_count > settings.reset_local_crit_iter) {
+            this->combined_criterion =
+                gko::stop::Combined::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build()
+                            .with_max_iters(new_max_iters)
+                            .on(settings.executor),
+                        gko::stop::ResidualNormReduction<ValueType>::build()
+                            .with_reduction_factor(
+                                metadata.local_solver_tolerance)
+                            .on(settings.executor))
+                    .on(settings.executor);
+        }
         if (settings.enable_logging) {
             this->combined_criterion->add_logger(this->record_logger);
         }


### PR DESCRIPTION
This PR makes criterion reset possible between the subdomain updates to allow for more flexibility between the domain updates and finer control. It also makes logging optional as there is a significant overhead with the creation and add of the record logger.